### PR TITLE
Validate and trim whitespace for city and state

### DIFF
--- a/src/components/Checkout/CheckoutContainer.js
+++ b/src/components/Checkout/CheckoutContainer.js
@@ -38,12 +38,14 @@ const CheckoutContainer = ({ orderContext }) => {
           .required('Required'),
         address: Yup.string().required('Required'),
         city: Yup.string()
+          .trim()
           .matches(alpha, {
             message: 'Enter Valid City Name',
             excludeEmptyString: true,
           })
           .required('Required'),
         state: Yup.string()
+          .trim()
           .matches(alpha, {
             message: 'Enter Valid State Name',
             excludeEmptyString: true,

--- a/src/components/Payment/PaymentContainer.js
+++ b/src/components/Payment/PaymentContainer.js
@@ -131,6 +131,8 @@ class PaymentContainer extends React.Component {
     orderInfo.paypalFeesEnabled = this.state.paypalFeesEnabled
     orderInfo.totalPrice = this.state.currentTotal
     orderInfo.paypalFeeInfo = this.state
+    orderInfo.userInfo.state = orderInfo.userInfo.state.trim()
+    orderInfo.userInfo.city = orderInfo.userInfo.city.trim()
 
     if (sendOrderData) {
       axios


### PR DESCRIPTION
Accept city and state with leading/trailing whitespace in yup validation. Trimmed said whitespace before calling Checkout lambda that sends to backend. Tested by making a mock order - when looking at the entry in the database, whitespace was trimmed from either ends of city and state values.