### PR TITLE
Remove periods from email address

### DIFF
--- a/src/functions/sendOrderEmail.js
+++ b/src/functions/sendOrderEmail.js
@@ -6,7 +6,7 @@ exports.handler = async (event, context, callback) => {
   sgMail.setApiKey(SENDGRID_API_KEY)
 
   const payload = JSON.parse(event.body)
-  const customerEmail = payload.userInfo.email
+  const customerEmail = payload.userInfo.email.replace(/\./g,'')
   const customerName = payload.userInfo.firstName + " " + payload.userInfo.lastName
 
 


### PR DESCRIPTION
Replace periods in email address with empty characters in order to normalize address when comparing to paypal email. This should ensure confirmation emails are sent despite having periods in the address.