### PR TITLE
updated new default page to be comiket

### DIFF
--- a/src/components/Index/landingImage.js
+++ b/src/components/Index/landingImage.js
@@ -18,7 +18,7 @@ const LandingImage = ({ landingImageData, landingText, landingSubtitle }) => {
           <span css={shippingText}>{landingSubtitle}</span>
         </div>
         <div css={lineBreakSm}></div>
-        <Link to="/products/weiss">
+        <Link to="/products/comiket">
           <div css={shopNow}>
             <span>EXPLORE NOW</span>
           </div>


### PR DESCRIPTION
When clicking on the "Explore Now" button on the homepage, it will now transition to the comiket page instead of the weiss page since the former is higher in demand